### PR TITLE
Explicitly set variable types

### DIFF
--- a/._wb/tool/phip-flow/config.json
+++ b/._wb/tool/phip-flow/config.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://raw.githubusercontent.com/FredHutch/bash-workbench/main/docs/schema.json",
     "name": "PhIP-Seq",
     "description": "PhIP-Seq common analysis workflows",
     "args": {

--- a/templates/join_organisms.py
+++ b/templates/join_organisms.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import os
+import pandas as pd
+
+peptide_dtypes = dict(
+    peptide=str,
+    n_replicates=int,
+    EBS=float,
+    hit=str,
+    sample=str,
+    public=bool
+)
+
+org_dtypes = dict(
+    sample=str,
+    organism=str,
+    n_hits_all=int,
+    n_discordant_all=int,
+    max_ebs_all=float,
+    mean_ebs_all=float,
+    n_hits_public=int,
+    n_discordant_public=int,
+    max_ebs_public=float,
+    mean_ebs_public=float,
+    
+)
+
+for suffix, dtype_dict in [
+    ("peptide.ebs.csv.gz", peptide_dtypes),
+    ("organism.summary.csv.gz", org_dtypes)
+]:
+
+    pd.concat([
+        pd.read_csv(
+            os.path.join("input", fp), 
+            dtype=dtype_dict
+        )
+        for fp in os.listdir("input")
+        if fp.endswith(suffix)
+    ]).to_csv(
+        suffix,
+        index=None
+    )

--- a/workflows/aggregate.nf
+++ b/workflows/aggregate.nf
@@ -38,21 +38,7 @@ process join_organisms {
     output: path "*.csv.gz"
     when: params.summarize_by_organism
     shell:
-    """#!/usr/bin/env python3
-import os
-import pandas as pd
-
-for suffix in ["peptide.ebs.csv.gz", "organism.summary.csv.gz"]:
-
-    pd.concat([
-        pd.read_csv(
-            os.path.join("input", fp)
-        )
-        for fp in os.listdir("input")
-        if fp.endswith(suffix)
-    ]).to_csv(suffix, index=None)
-
-    """
+    template 'join_organisms.py'
 }
 
 workflow AGG {


### PR DESCRIPTION
This PR addresses a bug observed by Ryan Basom where the `hit` column of the peptide results table will contain the values:
- True
- False
- TRUE
- FALSE
- DISCORDANT

After digging in, I realized that this was caused by pandas reading in columns containing only TRUE/FALSE as bools, while columns with TRUE/FALSE/DISCORDANT were being read as strings.