### PR TITLE
patch aggregate workflow

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -90,7 +90,7 @@ params{
     edgeR_threshold = 0.05
 
     // Column in the sample table used for mapping replicates to samples
-    sample_grouping_col = ""
+    sample_grouping_col = "sample_id"
 
     // Optional, a CSV containing public epitopes
     public_epitopes_csv = "$projectDir/templates/public_epitope_template.csv"

--- a/nextflow.config
+++ b/nextflow.config
@@ -90,7 +90,7 @@ params{
     edgeR_threshold = 0.05
 
     // Column in the sample table used for mapping replicates to samples
-    sample_grouping_col = "sample_id"
+    sample_grouping_col = ""
 
     // Optional, a CSV containing public epitopes
     public_epitopes_csv = "$projectDir/templates/public_epitope_template.csv"

--- a/templates/aggregate_organisms.py
+++ b/templates/aggregate_organisms.py
@@ -69,13 +69,13 @@ class AggregatePhIP:
         self.logger.info(f"Z-score threshold: {self.zscore_threshold}")
 
         # Read in the z-scores
-        zscores_fp = "!{params.dataset_prefix}_zscore.csv"
+        zscores_fp = "!{params.dataset_prefix}_zscore.csv.gz"
         self.logger.info(f"Reading in z-scores from: {zscores_fp}")
         assert os.path.exists(zscores_fp)
         self.zscores = pd.read_csv(zscores_fp, index_col=0)
 
         # Read in the edgeR hits (if present)
-        edgeR_hits_fp = "!{params.dataset_prefix}_edgeR_hits.csv"
+        edgeR_hits_fp = "!{params.dataset_prefix}_edgeR_hits.csv.gz"
         if os.path.exists(edgeR_hits_fp):
             self.logger.info(f"Reading in edgeR hits from: {edgeR_hits_fp}")
             self.edgeR_hits = pd.read_csv(
@@ -125,7 +125,7 @@ class AggregatePhIP:
         """Read a mapping of replicates to samples."""
 
         # The user must specify a CSV containing the sample mapping
-        sample_mapping_fp = "!{params.dataset_prefix}_sample_annotation_table.csv"
+        sample_mapping_fp = "!{params.dataset_prefix}_sample_annotation_table.csv.gz"
         self.logger.info(f"Reading in sample mapping from: {sample_mapping_fp}")
         assert os.path.exists(sample_mapping_fp)
 
@@ -146,7 +146,7 @@ class AggregatePhIP:
     def read_peptide_mapping(self) -> pd.DataFrame:
         """Read the table mapping peptides (by ID) to organism, protein, and start position ('pos')."""
 
-        peptide_mapping_fp = "!{params.dataset_prefix}_peptide_annotation_table.csv"
+        peptide_mapping_fp = "!{params.dataset_prefix}_peptide_annotation_table.csv.gz"
         self.logger.info(f"Reading in peptide mappings from: {peptide_mapping_fp}")
         assert os.path.exists(peptide_mapping_fp)
 

--- a/templates/aggregate_organisms.py
+++ b/templates/aggregate_organisms.py
@@ -101,7 +101,7 @@ class AggregatePhIP:
         # Save to CSV
         self.logger.info("Writing organism-level outputs to CSV")
         self.organism_table.to_csv("!{sample_id}.organism.summary.csv.gz", index=None)
-        
+
         self.logger.info("Done")
 
     def setup_logging(self) -> logging.Logger:
@@ -133,15 +133,26 @@ class AggregatePhIP:
         df = pd.read_csv(sample_mapping_fp, index_col=0)
         self.logger.info(f"Sample mapping table has {df.shape[0]:,} rows and {df.shape[1]:,} columns")
 
-        # The user must specify the column used to group replicates
+        # If the user specified a column used to group replicates
         # from the same sample
         sample_grouping_col = "!{params.sample_grouping_col}"
+        if len(sample_grouping_col) > 0:
 
-        msg = f"Column '{sample_grouping_col}' not found ({', '.join(df.columns.values)})"
-        assert sample_grouping_col in df.columns.values, msg
+            # Make sure that the column is present in the table
+            msg = f"Column '{sample_grouping_col}' not found ({', '.join(df.columns.values)})"
+            assert sample_grouping_col in df.columns.values, msg
 
-        # Return the column mapping of replicates to samples
-        return df[sample_grouping_col]
+            # Return the column mapping of replicates to samples
+            return df[sample_grouping_col]
+
+        # Otherwise, if no grouping was specified
+        else:
+
+            # Just treat each sample the same
+            return {
+                int(replicate_id): str(replicate_id)
+                for replicate_id in df.index.values
+            }
 
     def read_peptide_mapping(self) -> pd.DataFrame:
         """Read the table mapping peptides (by ID) to organism, protein, and start position ('pos')."""

--- a/templates/split_samples.py
+++ b/templates/split_samples.py
@@ -27,7 +27,7 @@ def setup_logging() -> logging.Logger:
 logger = setup_logging()
 
 # The user must specify a CSV containing the sample mapping
-sample_mapping_fp = "!{params.dataset_prefix}_sample_annotation_table.csv"
+sample_mapping_fp = "!{params.dataset_prefix}_sample_annotation_table.csv.gz"
 logger.info(f"Reading in sample mapping from: {sample_mapping_fp}")
 assert os.path.exists(sample_mapping_fp)
 

--- a/templates/split_samples.py
+++ b/templates/split_samples.py
@@ -35,19 +35,30 @@ assert os.path.exists(sample_mapping_fp)
 df = pd.read_csv(sample_mapping_fp, index_col=0)
 logger.info(f"Sample mapping table has {df.shape[0]:,} rows and {df.shape[1]:,} columns")
 
-# The user must specify the column used to group replicates
+# If the user specified a column used to group replicates
 # from the same sample
 sample_grouping_col = "!{params.sample_grouping_col}"
+if len(sample_grouping_col) > 0:
 
-msg = f"Column '{sample_grouping_col}' not found ({', '.join(df.columns.values)})"
-assert sample_grouping_col in df.columns.values, msg
+    # Make sure that the column is present in the table
+    msg = f"Column '{sample_grouping_col}' not found ({', '.join(df.columns.values)})"
+    assert sample_grouping_col in df.columns.values, msg
 
-# Write out a file containing the unique list of sample names
-df.reindex(
-    columns=[sample_grouping_col]
-).drop_duplicates(
-).to_csv(
-    "sample_list",
-    header=None,
-    index=None
-)
+    # Write out a file containing the unique list of sample names
+    df.reindex(
+        columns=[sample_grouping_col]
+    ).drop_duplicates(
+    ).to_csv(
+        "sample_list",
+        header=None,
+        index=None
+    )
+
+# If no such grouping was found
+else:
+
+    # Just write out a list of each replicate
+    with open("sample_list", "w") as handle:
+        handle.write(
+            "\n".join(list(map(str, df.index.values)))
+        )


### PR DESCRIPTION
@sminot 

In response to #68 , I've patched the input files to include the ".gz" extension, here.

Also discussed in that issue, I think the default behavior when a user does not provide the `--sample_grouping_col` (e.g. if no sample replicates exist), then the workflow should simply skip aggregating samples. It seems simply setting the default value for that parameter as "sample_id" as the default value won't work either, AFAICT because sample_id is used as the index for locating samples when you [shard the aggregate_organisms](https://github.com/matsengrp/phip-flow/blob/a60f8ebf29224ce5227064fc511af3df16b443f2/workflows/aggregate.nf#L7) step. Can you think of an easy way to skip sample aggregation? 

P.S. I'm not sure if you have a Virscan testing/dev set, but I'm just running
```
nextflow run main.nf \
        --summarize_by_organism true \
        --peptide_seq_col "Prot" \
        --peptide_org_col "Virus" \
        --sample_grouping_col "technical_replicate_id" \
        -profile docker \
        --results "$(date -I)"
```
which runs the default [pan-CoV-example data](https://github.com/matsengrp/phip-flow/tree/main/data/pan-cov-example) data. I think this should be fine?

All advice (/ pushes to this branch) welcomed and appreciated!
