### PR TITLE
Adding support for local singularity and apptainer profiles

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -123,6 +123,14 @@ profiles {
         docker.enabled = true
     }
 
+
+    singularity {
+        enabled = true
+        autoMounts = true
+        cacheDir = 'singularity_cache' 
+        runOptions = '--contain -W /tmp/ -B ${HOME},${PWD}'
+    }
+ 
     // Run batch submission assuming docker is installed with the latest image
     cluster {
 
@@ -130,7 +138,7 @@ profiles {
             enabled = true
             autoMounts = true
             cacheDir = 'singularity_cache' 
-            runOptions = '--contain -W /tmp/'
+            runOptions = '--contain -W /tmp/ -B ${HOME},${PWD}'
         }
 
         process {

--- a/nextflow.config
+++ b/nextflow.config
@@ -125,10 +125,17 @@ profiles {
 
 
     singularity {
-        enabled = true
-        autoMounts = true
-        cacheDir = 'singularity_cache' 
-        runOptions = '--contain -W /tmp/ -B ${HOME},${PWD}'
+        singularity.enabled = true
+        singularity.autoMounts = true
+        //singularity.cacheDir = 'singularity_cache'
+        singularity.runOptions = '--contain -W /tmp/ -B ${HOME},${PWD}'
+    }
+
+    apptainer {
+        apptainer.enabled = true
+        apptainer.autoMounts = true
+        //apptainer.cacheDir = 'apptainer_cache'
+        apptainer.runOptions = '--contain -W /tmp/ -B ${HOME},${PWD}'
     }
  
     // Run batch submission assuming docker is installed with the latest image


### PR DESCRIPTION
First of all, let me thank you for your work on this pipeline. It really integrates a series of useful tools in a neat package.

As I'm sure you're aware, Docker is not universally used because of the lack of sandboxing and ease of privilege escalation.
For my application, I rather use Apptainer, which is a recent open-source fork of singularity. This pull request creates two new local profiles to allow these tools to be used.

Very few modifications were made, as this will automatically use the Docker containers that are already specified.

I have run the basic tests of the pipeline and it seems to be working fine.

Please consider the inclusion of this pull request in your code and keep up the good work.

Kind regards, José Afonso Guerra-Assuncao